### PR TITLE
[admin] 設備編集フォームの都営路線表示バグを修正 (#33)

### DIFF
--- a/apps/admin/src/app/api/operators/[operatorId]/route.test.ts
+++ b/apps/admin/src/app/api/operators/[operatorId]/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { PUT, DELETE } from './route';
 
 vi.mock('@furatora/database/client', () => ({
@@ -35,7 +35,7 @@ describe('PUT /api/operators/[operatorId]', () => {
     const mockReturning = vi.fn().mockResolvedValue([mockOperator]);
     const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
     const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-    vi.mocked(db.update).mockReturnValue({ set: mockSet } as ReturnType<typeof db.update>);
+    (db.update as Mock).mockReturnValue({ set: mockSet });
 
     const request = new Request(`http://localhost/api/operators/${OPERATOR_ID}`, {
       method: 'PUT',
@@ -69,7 +69,7 @@ describe('PUT /api/operators/[operatorId]', () => {
     const mockReturning = vi.fn().mockResolvedValue([]);
     const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
     const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-    vi.mocked(db.update).mockReturnValue({ set: mockSet } as ReturnType<typeof db.update>);
+    (db.update as Mock).mockReturnValue({ set: mockSet });
 
     const request = new Request(`http://localhost/api/operators/${OPERATOR_ID}`, {
       method: 'PUT',
@@ -89,7 +89,7 @@ describe('PUT /api/operators/[operatorId]', () => {
     const mockReturning = vi.fn().mockRejectedValue(new Error('DB error'));
     const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
     const mockSet = vi.fn().mockReturnValue({ where: mockWhere });
-    vi.mocked(db.update).mockReturnValue({ set: mockSet } as ReturnType<typeof db.update>);
+    (db.update as Mock).mockReturnValue({ set: mockSet });
 
     const request = new Request(`http://localhost/api/operators/${OPERATOR_ID}`, {
       method: 'PUT',
@@ -114,7 +114,7 @@ describe('DELETE /api/operators/[operatorId]', () => {
     const { db } = await import('@furatora/database/client');
     const mockReturning = vi.fn().mockResolvedValue([mockOperator]);
     const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
-    vi.mocked(db.delete).mockReturnValue({ where: mockWhere } as ReturnType<typeof db.delete>);
+    (db.delete as Mock).mockReturnValue({ where: mockWhere });
 
     const request = new Request(`http://localhost/api/operators/${OPERATOR_ID}`, {
       method: 'DELETE',
@@ -131,7 +131,7 @@ describe('DELETE /api/operators/[operatorId]', () => {
     const { db } = await import('@furatora/database/client');
     const mockReturning = vi.fn().mockResolvedValue([]);
     const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
-    vi.mocked(db.delete).mockReturnValue({ where: mockWhere } as ReturnType<typeof db.delete>);
+    (db.delete as Mock).mockReturnValue({ where: mockWhere });
 
     const request = new Request(`http://localhost/api/operators/${OPERATOR_ID}`, {
       method: 'DELETE',
@@ -148,7 +148,7 @@ describe('DELETE /api/operators/[operatorId]', () => {
     const { db } = await import('@furatora/database/client');
     const mockReturning = vi.fn().mockRejectedValue(new Error('DB error'));
     const mockWhere = vi.fn().mockReturnValue({ returning: mockReturning });
-    vi.mocked(db.delete).mockReturnValue({ where: mockWhere } as ReturnType<typeof db.delete>);
+    (db.delete as Mock).mockReturnValue({ where: mockWhere });
 
     const request = new Request(`http://localhost/api/operators/${OPERATOR_ID}`, {
       method: 'DELETE',

--- a/apps/admin/src/app/api/operators/route.test.ts
+++ b/apps/admin/src/app/api/operators/route.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
 import { GET, POST } from './route';
 
 vi.mock('@furatora/database/client', () => ({
@@ -32,7 +32,7 @@ describe('GET /api/operators', () => {
     const { db } = await import('@furatora/database/client');
     const mockOrderBy = vi.fn().mockResolvedValue([mockOperator]);
     const mockFrom = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-    vi.mocked(db.select).mockReturnValue({ from: mockFrom } as ReturnType<typeof db.select>);
+    (db.select as Mock).mockReturnValue({ from: mockFrom });
 
     const response = await GET();
     const data = await response.json();
@@ -45,7 +45,7 @@ describe('GET /api/operators', () => {
     const { db } = await import('@furatora/database/client');
     const mockOrderBy = vi.fn().mockRejectedValue(new Error('DB error'));
     const mockFrom = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
-    vi.mocked(db.select).mockReturnValue({ from: mockFrom } as ReturnType<typeof db.select>);
+    (db.select as Mock).mockReturnValue({ from: mockFrom });
 
     const response = await GET();
     const data = await response.json();
@@ -64,7 +64,7 @@ describe('POST /api/operators', () => {
     const { db } = await import('@furatora/database/client');
     const mockReturning = vi.fn().mockResolvedValue([mockOperator]);
     const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
-    vi.mocked(db.insert).mockReturnValue({ values: mockValues } as ReturnType<typeof db.insert>);
+    (db.insert as Mock).mockReturnValue({ values: mockValues });
 
     const request = new Request('http://localhost/api/operators', {
       method: 'POST',
@@ -97,7 +97,7 @@ describe('POST /api/operators', () => {
     const { db } = await import('@furatora/database/client');
     const mockReturning = vi.fn().mockRejectedValue(new Error('DB error'));
     const mockValues = vi.fn().mockReturnValue({ returning: mockReturning });
-    vi.mocked(db.insert).mockReturnValue({ values: mockValues } as ReturnType<typeof db.insert>);
+    (db.insert as Mock).mockReturnValue({ values: mockValues });
 
     const request = new Request('http://localhost/api/operators', {
       method: 'POST',

--- a/apps/admin/src/app/api/stations/route.ts
+++ b/apps/admin/src/app/api/stations/route.ts
@@ -1,7 +1,7 @@
 import { NextResponse } from 'next/server';
 import { db } from '@furatora/database/client';
 import { stations, stationLines, lines, stationConnections } from '@furatora/database/schema';
-import { asc, eq } from 'drizzle-orm';
+import { asc, and, eq, isNotNull } from 'drizzle-orm';
 
 export async function GET(request: Request) {
   try {
@@ -37,11 +37,15 @@ export async function GET(request: Request) {
           code: stations.code,
           lineId: lines.id,
           lineName: lines.name,
+          odptRailwayId: stationConnections.odptRailwayId,
         })
         .from(stationConnections)
         .innerJoin(stations, eq(stationConnections.connectedStationId, stations.id))
-        .innerJoin(lines, eq(stationConnections.connectedRailwayId, lines.id))
-        .where(eq(stationConnections.stationId, connectedFromStationId))
+        .leftJoin(lines, eq(stationConnections.connectedRailwayId, lines.id))
+        .where(and(
+          eq(stationConnections.stationId, connectedFromStationId),
+          isNotNull(stationConnections.connectedStationId),
+        ))
         .orderBy(asc(lines.name));
       return NextResponse.json(result);
     }

--- a/apps/admin/src/app/stations/[stationId]/edit/page.tsx
+++ b/apps/admin/src/app/stations/[stationId]/edit/page.tsx
@@ -37,23 +37,36 @@ export default async function StationEditPage({ params }: Props) {
   const connectedRailwayIds = connectionRows
     .map((c) => c.connectedRailwayId)
     .filter((id): id is string => id !== null);
+  const unresolvedOdptRailwayIds = connectionRows
+    .filter((c) => c.connectedRailwayId === null && c.odptRailwayId !== null)
+    .map((c) => c.odptRailwayId as string);
 
-  const [connectedStationList, connectedLineList] = await Promise.all([
+  const [connectedStationList, connectedLineList, unresolvedLineList] = await Promise.all([
     connectedStationIds.length > 0
       ? db.select({ id: stations.id, name: stations.name }).from(stations).where(inArray(stations.id, connectedStationIds))
       : Promise.resolve([]),
     connectedRailwayIds.length > 0
       ? db.select({ id: lines.id, name: lines.name }).from(lines).where(inArray(lines.id, connectedRailwayIds))
       : Promise.resolve([]),
+    unresolvedOdptRailwayIds.length > 0
+      ? db.select({ odptRailwayId: lines.odptRailwayId, name: lines.name }).from(lines).where(inArray(lines.odptRailwayId, unresolvedOdptRailwayIds))
+      : Promise.resolve([]),
   ]);
 
   const stationNameMap = Object.fromEntries(connectedStationList.map((s) => [s.id, s.name]));
-  const lineNameMap = Object.fromEntries(connectedLineList.map((l) => [l.id, l.name]));
+  const lineNameByIdMap = Object.fromEntries(connectedLineList.map((l) => [l.id, l.name]));
+  const lineNameByOdptIdMap = Object.fromEntries(
+    unresolvedLineList
+      .filter((l): l is { odptRailwayId: string; name: string } => l.odptRailwayId !== null)
+      .map((l) => [l.odptRailwayId, l.name])
+  );
 
   const connections: ConnectionRow[] = connectionRows.map((c) => ({
     id: c.id,
     connectedStationName: c.connectedStationId ? (stationNameMap[c.connectedStationId] ?? null) : null,
-    connectedLineName: c.connectedRailwayId ? (lineNameMap[c.connectedRailwayId] ?? null) : null,
+    connectedLineName: c.connectedRailwayId
+      ? (lineNameByIdMap[c.connectedRailwayId] ?? null)
+      : (c.odptRailwayId ? (lineNameByOdptIdMap[c.odptRailwayId] ?? null) : null),
     odptStationId: c.odptStationId,
     odptRailwayId: c.odptRailwayId,
     strollerDifficulty: c.strollerDifficulty,

--- a/apps/admin/src/components/FacilityForm.tsx
+++ b/apps/admin/src/components/FacilityForm.tsx
@@ -21,8 +21,9 @@ type ConnectedStation = {
   id: string;
   name: string;
   code: string | null;
-  lineId: string;
-  lineName: string;
+  lineId: string | null;
+  lineName: string | null;
+  odptRailwayId: string | null;
 }
 
 type Connection = {
@@ -154,7 +155,10 @@ export function FacilityForm({ stationId, initialData, isEdit = false }: Props) 
 
   const connectedStationData = [
     { value: '', label: '駅を選択' },
-    ...connectedStations.map((s) => ({ value: s.id, label: `${s.lineName} (${s.name})` })),
+    ...connectedStations.map((s) => {
+      const lineLabel = s.lineName ?? s.odptRailwayId?.replace('odpt.Railway:', '') ?? '(路線不明)';
+      return { value: s.id, label: `${lineLabel} (${s.name})` };
+    }),
   ];
 
   return (

--- a/apps/admin/vitest.config.ts
+++ b/apps/admin/vitest.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/test/setup.ts'],
     globals: true,
+    exclude: ['**/node_modules/**', '**/e2e/**'],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary

- `api/stations` の `connectedFrom` クエリで `innerJoin` → `leftJoin` に変更し、`connectedRailwayId` が `null` の都営路線レコードが除外されていた問題を修正
- `FacilityForm` のドロップダウンラベルで、路線名が未解決の場合に `odptRailwayId` からフォールバック表示するよう修正
- `StationEditPage` で `connectedRailwayId` が `null` のとき `odptRailwayId` で路線名を検索する2段階フォールバックを実装
- 既存テストファイルの Vitest / DrizzleORM ユニオン型不整合による型エラーを合わせて修正

## Test plan

- [x] Vitest ユニットテスト: 58テスト全パス
- [x] Playwright E2Eテスト: 13テスト全パス
- [x] TypeScript コンパイル: エラーなし
- [x] 手動確認: 都営路線が「乗換可能な駅」ドロップダウンに表示されることを確認

Closes #33